### PR TITLE
return cellDividerData only if it is not null

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -104,7 +104,7 @@ NSData *cellDividerData;
         if (!cellDividerData) cellDividerData = %orig;
         return cellDividerData;
     }
-    if ([self respondsToSelector:@selector(hasCompatibilityOptions)] && self.hasCompatibilityOptions && self.compatibilityOptions.hasAdLoggingData) return cellDividerData;
+    if ([self respondsToSelector:@selector(hasCompatibilityOptions)] && self.hasCompatibilityOptions && self.compatibilityOptions.hasAdLoggingData) return cellDividerData ?: %orig;
     // if (isAdString(description)) return cellDividerData;
     return %orig;
 }


### PR DESCRIPTION
Same as in UnShorts, mainly intended for the iPads but for the first ad cell in list