### PR TITLE
Add new ads ID

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -159,13 +159,14 @@ static BOOL isProductList(YTICommand *command) {
 NSString *getAdString(NSString *description) {
     for (NSString *str in @[
         @"brand_promo",
-        @"brand_video_singleton",
+        @"brand_video_shelf",
         @"carousel_footered_layout",
         @"carousel_headered_layout",
         @"eml.expandable_metadata",
         @"feed_ad_metadata",
         @"full_width_portrait_image_layout",
         @"full_width_square_image_layout",
+        @"grid_ads_image_layout",
         @"landscape_image_wide_button_layout",
         @"post_shelf",
         @"product_carousel",

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.ps.ytx
 Name: YouTube X
-Version: 1.7.20
+Version: 1.7.21
 Architecture: iphoneos-arm
 Description: A YouTube improvement tweak.
 Maintainer: PoomSmart


### PR DESCRIPTION
`brand_video_singleton` is removed because it's just a music video shelf, not an actual YouTube Premium promotions.

`brand_video_shelf` Got from my research.
<img width="1180" height="820" alt="IMG_4436" src="https://github.com/user-attachments/assets/672668b1-f432-48f1-9581-0ba723fb24ef" />
<img width="2360" height="1640" alt="IMG_4437" src="https://github.com/user-attachments/assets/b76452a4-ad69-4ced-a26e-119345262233" />

`grid_ads_image_layout` Probably got from US account. (researched with @MCTMS8)
<img width="1125" height="2436" alt="IMG_6234" src="https://github.com/user-attachments/assets/1e479a14-a7c3-4da7-8a5a-1eef88f4330a" />
<img width="1125" height="2436" alt="IMG_6243" src="https://github.com/user-attachments/assets/72ebacb8-cf55-4769-988b-35d899c7923b" />
